### PR TITLE
TASK: Avoid switching local navigation border width of active element

### DIFF
--- a/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/LocalNavigation/LocalNavigation.scss
+++ b/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/LocalNavigation/LocalNavigation.scss
@@ -16,7 +16,7 @@
 				border-left: 2px solid map-get($brand-colors, primary);
 			}
 
-			&:hover {
+			&:not(.active):hover {
 				border-left: 1px solid map-get($brand-colors, primary);
 			}
 			color: rgba(0, 0, 0, 0.55);


### PR DESCRIPTION
On hovering the active local navigation item, the border size switches from 2px to 1px, making the text jump around, which causes bad UX. This change fixes that, by only changing border size on non-active items.