### PR TITLE
TASK: Remove jonnitto/sitemap

### DIFF
--- a/DistributionPackages/Neos.DocsNeosIo/Configuration/NodeTypes.Constraint.Document.BackendOnly.yaml
+++ b/DistributionPackages/Neos.DocsNeosIo/Configuration/NodeTypes.Constraint.Document.BackendOnly.yaml
@@ -3,7 +3,7 @@
   superTypes:
     'Neos.DocsNeosIo:Mixin.HideSeo': true
     'Neos.GoogleAnalytics:StatsTabMixin': false
-    'Jonnitto.Sitemap:RemoveFromSitemap': true
+    'Neos.Seo:NoindexMixin': true
   properties:
     _hiddenInIndex:
       defaultValue: true

--- a/DistributionPackages/Neos.DocsNeosIo/composer.json
+++ b/DistributionPackages/Neos.DocsNeosIo/composer.json
@@ -23,7 +23,6 @@
         "flowpack/cachebuster": "^1.0",
         "flowpack/nodetemplates": "~1.0",
         "moc/notfound": "^3.1",
-        "jonnitto/sitemap": "^3.2",
         "sitegeist/neosguidelines": "^1.2",
         "sitegeist/silhouettes": "^1.0",
 


### PR DESCRIPTION
This package is obsolete. All features has been integrated into Neos.Seo