### PR TITLE
TASK: Reduce bottom margin of last side-nav item

### DIFF
--- a/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
+++ b/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
@@ -43,7 +43,7 @@
     }
 
     > li:last-child {
-      margin-bottom: 160px;
+      margin-bottom: 40px;
     }
 
     li {


### PR DESCRIPTION
This helps prevent a jumping content user-experience when hovering over the sidenav with expanded navigation items which cause a vertical overflow.
A maybe better solution would be to switch the "overflow-y: auto" to "overflow-y: overlay", but that also has drawbacks from UX, while this change does not have any bad side effects (AFAIS).