### PR TITLE
TASK: Prevent the hover scrollbar from squashing content

### DIFF
--- a/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
+++ b/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
@@ -90,9 +90,9 @@
 
     // Only show scrollbar on hover
     &:hover {
-	  overflow-y: auto;
+      overflow-y: auto;
       overflow-y: overlay;
-	  -ms-overflow-style: -ms-autohiding-scrollbar;
+      -ms-overflow-style: -ms-autohiding-scrollbar;
     }
 
 

--- a/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
+++ b/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
@@ -91,6 +91,7 @@
     // Only show scrollbar on hover
     &:hover {
       overflow-y: overlay;
+	  -ms-overflow-style: -ms-autohiding-scrollbar;
     }
 
 

--- a/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
+++ b/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
@@ -90,7 +90,7 @@
 
     // Only show scrollbar on hover
     &:hover {
-      overflow-y: auto;
+      overflow-y: overlay;
     }
 
 

--- a/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
+++ b/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Header/Header.scss
@@ -90,6 +90,7 @@
 
     // Only show scrollbar on hover
     &:hover {
+	  overflow-y: auto;
       overflow-y: overlay;
 	  -ms-overflow-style: -ms-autohiding-scrollbar;
     }


### PR DESCRIPTION
Related to #8 and one attempt at actually fixing the issue shown there. However, this leads to some labels/icons possibly being cut, which is also not optimal (but still better than the content jumping).