### PR TITLE
BUGFIX: fixed backend document listed in search

### DIFF
--- a/DistributionPackages/Neos.DocsNeosIo/Configuration/NodeTypes.Constraint.Document.BackendOnly.yaml
+++ b/DistributionPackages/Neos.DocsNeosIo/Configuration/NodeTypes.Constraint.Document.BackendOnly.yaml
@@ -1,5 +1,8 @@
 'Neos.DocsNeosIo:Constraint.Document.BackendOnly':
   abstract: true
+  search:
+    fulltext:
+      enable: false
   superTypes:
     'Neos.DocsNeosIo:Mixin.HideSeo': true
     'Neos.GoogleAnalytics:StatsTabMixin': false


### PR DESCRIPTION
Bug:

- Search for tags ( https://docs.neos.io/search?search=tags )
- Tags page is listed

Fix:

- add search fulltext `false` to backend only documents