### PR TITLE
FEATURE: Allow the new version of Carbon.IncludeAssets

### DIFF
--- a/DistributionPackages/Neos.DocsNeosIo/composer.json
+++ b/DistributionPackages/Neos.DocsNeosIo/composer.json
@@ -19,7 +19,7 @@
         "carbon/compression": "^1.1",
         "carbon/hyphen": "^1.1",
         "carbon/link": "^1.0",
-        "carbon/includeassets": "^3.5",
+        "carbon/includeassets": "^3.5 || ^4.0",
         "codeq/unicodenormalizer": "~2.1",
         "flowpack/cachebuster": "^1.0",
         "flowpack/nodetemplates": "~1.0",


### PR DESCRIPTION
I released a new Version of [Carbon.IncludeAssets](https://github.com/CarbonPackages/Carbon.IncludeAssets/releases/tag/4.0.0)
* Change license to GPL-3
* Add [propTypes](https://github.com/PackageFactory/atomic-fusion-proptypes)
* Add Wrapper setting: If set, the generated tags will be wrapped. `{content}` will be replaced with the tags. Example: `Wrapper: '<!--[if lt IE 9]>{content}<![endif]-->'`. You can set this property also in the Fusion prototypes `Carbon.IncludeAssets:Collection` and `Carbon.IncludeAssets:File`.
* Raise minimum Neos Version to 4.3
* Update Build script