### PR TITLE
TASK: remove link too neos twitter and facebook profile

### DIFF
--- a/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Footer/Footer.fusion
+++ b/DistributionPackages/Neos.DocsNeosIo/Resources/Private/Fusion/Component/Footer/Footer.fusion
@@ -35,10 +35,6 @@ prototype(Neos.DocsNeosIo:Component.Footer) < prototype(Neos.Fusion:Component) {
                             class="fab fa-github"></i>
                             GitHub</a></li>
                         <li><a rel="me noopener" target="_blank" href="https://neos.social/@team"><i class="fab fa-mastodon"></i> Mastodon</a></li>
-                        <li><a target="_blank" rel="noopener" href="https://twitter.com/NeosCMS"><i
-                            class="fab fa-twitter"></i> Twitter</a></li>
-                        <li><a target="_blank" rel="noopener" href="https://www.facebook.com/NeosCMS"><i
-                            class="fab fa-facebook"></i> Facebook</a></li>
                         <li><a target="_blank" rel="noopener" href="https://youtube.com/c/NeosCMS"><i
                             class="fab fa-youtube"></i> YouTube</a></li>
                     </ul>


### PR DESCRIPTION
We also removed these links on the neos.io website already as we currently dont maintain/use these profiles.

See: https://github.com/neos/Neos.NeosIo/pull/532