### PR TITLE
TASK: Upgrade to latest Neos versions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09fcd7456ce13e9b0c4671832e9a4f5c",
+    "content-hash": "d4b95101a9b0a5193274e2e5c39c1ed6",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -58,16 +58,16 @@
         },
         {
             "name": "brick/math",
-            "version": "0.12.3",
+            "version": "0.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba"
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/866551da34e9a618e64a819ee1e01c20d8a588ba",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba",
+                "url": "https://api.github.com/repos/brick/math/zipball/fc7ed316430118cc7836bf45faff18d5dfc8de04",
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04",
                 "shasum": ""
             },
             "require": {
@@ -106,7 +106,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.12.3"
+                "source": "https://github.com/brick/math/tree/0.13.1"
             },
             "funding": [
                 {
@@ -114,20 +114,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-28T13:11:00+00:00"
+            "time": "2025-03-29T13:50:30+00:00"
         },
         {
             "name": "carbon/eel",
-            "version": "2.21.1",
+            "version": "2.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPackages/Carbon.Eel.git",
-                "reference": "9ea2801fe05a2bbda12ab0a4475054babceb4d97"
+                "reference": "be3abdb0c93245908e22cf457a2edd4c411c744e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPackages/Carbon.Eel/zipball/9ea2801fe05a2bbda12ab0a4475054babceb4d97",
-                "reference": "9ea2801fe05a2bbda12ab0a4475054babceb4d97",
+                "url": "https://api.github.com/repos/CarbonPackages/Carbon.Eel/zipball/be3abdb0c93245908e22cf457a2edd4c411c744e",
+                "reference": "be3abdb0c93245908e22cf457a2edd4c411c744e",
                 "shasum": ""
             },
             "require": {
@@ -171,7 +171,7 @@
             ],
             "support": {
                 "issues": "https://github.com/CarbonPackages/Carbon.Eel/issues",
-                "source": "https://github.com/CarbonPackages/Carbon.Eel/tree/2.21.1"
+                "source": "https://github.com/CarbonPackages/Carbon.Eel/tree/2.22.0"
             },
             "funding": [
                 {
@@ -183,7 +183,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-11T08:30:52+00:00"
+            "time": "2025-06-09T09:03:25+00:00"
         },
         {
             "name": "carbon/fileloader",
@@ -1997,16 +1997,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.20.3",
+            "version": "2.20.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "17d28b5c4cac212ca92730d9a26e32a0b1516126"
+                "reference": "71550106d491c3f888636b731c805473de3c8583"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/17d28b5c4cac212ca92730d9a26e32a0b1516126",
-                "reference": "17d28b5c4cac212ca92730d9a26e32a0b1516126",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/71550106d491c3f888636b731c805473de3c8583",
+                "reference": "71550106d491c3f888636b731c805473de3c8583",
                 "shasum": ""
             },
             "require": {
@@ -2093,9 +2093,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.20.3"
+                "source": "https://github.com/doctrine/orm/tree/2.20.4"
             },
-            "time": "2025-05-02T17:07:53+00:00"
+            "time": "2025-06-09T20:24:12+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -2577,16 +2577,16 @@
         },
         {
             "name": "flowpack/elasticsearch-contentrepositoryadaptor",
-            "version": "9.0.0",
+            "version": "9.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor.git",
-                "reference": "ce4f262cd412b1be4ed05dee093d1993f39d07c0"
+                "reference": "fdf47630126bb7aaebe5bf8cd09c66bc4b513efd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/zipball/ce4f262cd412b1be4ed05dee093d1993f39d07c0",
-                "reference": "ce4f262cd412b1be4ed05dee093d1993f39d07c0",
+                "url": "https://api.github.com/repos/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/zipball/fdf47630126bb7aaebe5bf8cd09c66bc4b513efd",
+                "reference": "fdf47630126bb7aaebe5bf8cd09c66bc4b513efd",
                 "shasum": ""
             },
             "require": {
@@ -2691,9 +2691,9 @@
             "homepage": "http://flowpack.org/",
             "support": {
                 "issues": "https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/issues",
-                "source": "https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/tree/9.0.0"
+                "source": "https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/tree/9.0.2"
             },
-            "time": "2025-04-02T18:02:26+00:00"
+            "time": "2025-06-09T08:18:42+00:00"
         },
         {
             "name": "flowpack/listable",
@@ -3220,16 +3220,16 @@
         },
         {
             "name": "google/cloud-core",
-            "version": "v1.62.3",
+            "version": "v1.63.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-core.git",
-                "reference": "0c19d76e7f3b6810c4f2cc1330c693af2681c601"
+                "reference": "14461f7b53b261caeed7174f9d704d10881b02c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/0c19d76e7f3b6810c4f2cc1330c693af2681c601",
-                "reference": "0c19d76e7f3b6810c4f2cc1330c693af2681c601",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/14461f7b53b261caeed7174f9d704d10881b02c2",
+                "reference": "14461f7b53b261caeed7174f9d704d10881b02c2",
                 "shasum": ""
             },
             "require": {
@@ -3280,9 +3280,9 @@
             ],
             "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.62.3"
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.63.0"
             },
-            "time": "2025-05-20T19:49:54+00:00"
+            "time": "2025-06-13T20:36:13+00:00"
         },
         {
             "name": "google/cloud-storage",
@@ -3548,16 +3548,16 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v4.31.0",
+            "version": "v4.31.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "d59e31ce4bf0e4b48728e90c4d880839edb5be07"
+                "reference": "2b028ce8876254e2acbeceea7d9b573faad41864"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/d59e31ce4bf0e4b48728e90c4d880839edb5be07",
-                "reference": "d59e31ce4bf0e4b48728e90c4d880839edb5be07",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/2b028ce8876254e2acbeceea7d9b573faad41864",
+                "reference": "2b028ce8876254e2acbeceea7d9b573faad41864",
                 "shasum": ""
             },
             "require": {
@@ -3586,9 +3586,9 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.31.0"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v4.31.1"
             },
-            "time": "2025-05-14T16:17:23+00:00"
+            "time": "2025-05-28T18:52:35+00:00"
         },
         {
             "name": "grpc/grpc",
@@ -4225,16 +4225,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.4.1",
+            "version": "6.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "35d262c94959571e8736db1e5c9bc36ab94ae900"
+                "reference": "ce1fd2d47799bb60668643bc6220f6278a4c1d02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/35d262c94959571e8736db1e5c9bc36ab94ae900",
-                "reference": "35d262c94959571e8736db1e5c9bc36ab94ae900",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/ce1fd2d47799bb60668643bc6220f6278a4c1d02",
+                "reference": "ce1fd2d47799bb60668643bc6220f6278a4c1d02",
                 "shasum": ""
             },
             "require": {
@@ -4294,9 +4294,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.4.1"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.4.2"
             },
-            "time": "2025-04-04T13:08:07+00:00"
+            "time": "2025-06-03T18:27:04+00:00"
         },
         {
             "name": "laminas/laminas-code",
@@ -4782,16 +4782,16 @@
         },
         {
             "name": "matthiasmullie/minify",
-            "version": "1.3.73",
+            "version": "1.3.74",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matthiasmullie/minify.git",
-                "reference": "cb7a9297b4ab070909cefade30ee95054d4ae87a"
+                "reference": "a2593286a4135d03c6a6a9e9aeded5d41e931ce4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matthiasmullie/minify/zipball/cb7a9297b4ab070909cefade30ee95054d4ae87a",
-                "reference": "cb7a9297b4ab070909cefade30ee95054d4ae87a",
+                "url": "https://api.github.com/repos/matthiasmullie/minify/zipball/a2593286a4135d03c6a6a9e9aeded5d41e931ce4",
+                "reference": "a2593286a4135d03c6a6a9e9aeded5d41e931ce4",
                 "shasum": ""
             },
             "require": {
@@ -4802,8 +4802,7 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": ">=2.0",
                 "matthiasmullie/scrapbook": ">=1.3",
-                "phpunit/phpunit": ">=4.8",
-                "squizlabs/php_codesniffer": ">=3.0"
+                "phpunit/phpunit": ">=4.8"
             },
             "suggest": {
                 "psr/cache-implementation": "Cache implementation to use with Minify::cache"
@@ -4841,7 +4840,7 @@
             ],
             "support": {
                 "issues": "https://github.com/matthiasmullie/minify/issues",
-                "source": "https://github.com/matthiasmullie/minify/tree/1.3.73"
+                "source": "https://github.com/matthiasmullie/minify/tree/1.3.74"
             },
             "funding": [
                 {
@@ -4849,7 +4848,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-15T10:27:10+00:00"
+            "time": "2025-06-12T08:06:04+00:00"
         },
         {
             "name": "matthiasmullie/path-converter",
@@ -5125,16 +5124,16 @@
         },
         {
             "name": "neos/content-repository-search",
-            "version": "5.0.1",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/content-repository-search.git",
-                "reference": "8e982a0c22a156dd285c5c604f48bf3be9ed4d94"
+                "reference": "d9f955a23ffde44836e510fa3c73809a57196742"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/content-repository-search/zipball/8e982a0c22a156dd285c5c604f48bf3be9ed4d94",
-                "reference": "8e982a0c22a156dd285c5c604f48bf3be9ed4d94",
+                "url": "https://api.github.com/repos/neos/content-repository-search/zipball/d9f955a23ffde44836e510fa3c73809a57196742",
+                "reference": "d9f955a23ffde44836e510fa3c73809a57196742",
                 "shasum": ""
             },
             "require": {
@@ -5232,7 +5231,7 @@
             "description": "Common code and interface for a Neos CR search implementation",
             "support": {
                 "issues": "https://github.com/neos/content-repository-search/issues",
-                "source": "https://github.com/neos/content-repository-search/tree/5.0.1"
+                "source": "https://github.com/neos/content-repository-search/tree/5.0.3"
             },
             "funding": [
                 {
@@ -5240,11 +5239,11 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-05-18T19:03:06+00:00"
+            "time": "2025-06-09T08:14:56+00:00"
         },
         {
             "name": "neos/contentgraph-doctrinedbaladapter",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentgraph-doctrinedbaladapter.git",
@@ -5290,7 +5289,7 @@
         },
         {
             "name": "neos/contentrepository-core",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-core.git",
@@ -5350,7 +5349,7 @@
         },
         {
             "name": "neos/contentrepository-export",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-export.git",
@@ -5402,66 +5401,17 @@
             "time": "2025-04-02T10:05:05+00:00"
         },
         {
-            "name": "neos/contentrepository-legacynodemigration",
-            "version": "9.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/neos/contentrepository-legacynodemigration.git",
-                "reference": "458a40560304b3981e5c46911db9430e2326af3c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/neos/contentrepository-legacynodemigration/zipball/458a40560304b3981e5c46911db9430e2326af3c",
-                "reference": "458a40560304b3981e5c46911db9430e2326af3c",
-                "shasum": ""
-            },
-            "require": {
-                "league/flysystem": "^3",
-                "neos/contentrepository-core": "self.version",
-                "neos/contentrepository-export": "self.version",
-                "neos/neos": "self.version",
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "league/flysystem-memory": "^3",
-                "neos/behat": "*"
-            },
-            "type": "neos-package",
-            "autoload": {
-                "psr-4": {
-                    "Neos\\ContentRepository\\LegacyNodeMigration\\": "Classes"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-or-later"
-            ],
-            "description": "Migration from the Non-Event-Sourced to the Event-Sourced world",
-            "support": {
-                "docs": "https://docs.neos.io/",
-                "forum": "https://discuss.neos.io/",
-                "source": "https://github.com/neos/contentrepository-legacynodemigration.git"
-            },
-            "funding": [
-                {
-                    "url": "https://shop.neos.io/neosfunding/",
-                    "type": "custom"
-                }
-            ],
-            "time": "2025-04-04T16:45:07+00:00"
-        },
-        {
             "name": "neos/contentrepository-nodeaccess",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-nodeaccess.git",
-                "reference": "35f6733c07d72e88880591bda1c0c872a47a1df0"
+                "reference": "735268ef8826856d4c9ac3fd1697628a65ace38a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/contentrepository-nodeaccess/zipball/35f6733c07d72e88880591bda1c0c872a47a1df0",
-                "reference": "35f6733c07d72e88880591bda1c0c872a47a1df0",
+                "url": "https://api.github.com/repos/neos/contentrepository-nodeaccess/zipball/735268ef8826856d4c9ac3fd1697628a65ace38a",
+                "reference": "735268ef8826856d4c9ac3fd1697628a65ace38a",
                 "shasum": ""
             },
             "require": {
@@ -5572,11 +5522,11 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-02T10:05:05+00:00"
+            "time": "2025-06-02T20:43:15+00:00"
         },
         {
             "name": "neos/contentrepository-nodemigration",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-nodemigration.git",
@@ -5712,7 +5662,7 @@
         },
         {
             "name": "neos/contentrepository-structureadjustment",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepository-structureadjustment.git",
@@ -5848,16 +5798,16 @@
         },
         {
             "name": "neos/contentrepositoryregistry",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/contentrepositoryregistry.git",
-                "reference": "a81a88d8928e1a9722ed10d469b0f06b2678d3bc"
+                "reference": "92e386d879c9089e2aa5798e00819610d72cd111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/contentrepositoryregistry/zipball/a81a88d8928e1a9722ed10d469b0f06b2678d3bc",
-                "reference": "a81a88d8928e1a9722ed10d469b0f06b2678d3bc",
+                "url": "https://api.github.com/repos/neos/contentrepositoryregistry/zipball/92e386d879c9089e2aa5798e00819610d72cd111",
+                "reference": "92e386d879c9089e2aa5798e00819610d72cd111",
                 "shasum": ""
             },
             "require": {
@@ -5891,11 +5841,11 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T13:22:30+00:00"
+            "time": "2025-06-13T19:27:24+00:00"
         },
         {
             "name": "neos/diff",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/diff.git",
@@ -5936,7 +5886,7 @@
         },
         {
             "name": "neos/docs-neos-io",
-            "version": "dev-task/upgrade-neos9",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
                 "url": "./DistributionPackages/Neos.DocsNeosIo",
@@ -6465,7 +6415,7 @@
         },
         {
             "name": "neos/fusion",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/fusion.git",
@@ -6603,7 +6553,7 @@
         },
         {
             "name": "neos/fusion-afx",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/fusion-afx.git",
@@ -6902,7 +6852,7 @@
         },
         {
             "name": "neos/media",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/media.git",
@@ -7048,16 +6998,16 @@
         },
         {
             "name": "neos/media-browser",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/media-browser.git",
-                "reference": "44cbda8a831844c8735734a8eab1b559762e98e0"
+                "reference": "82daa7a8f08a91276c655c9b90ea800d9bc1c2ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/media-browser/zipball/44cbda8a831844c8735734a8eab1b559762e98e0",
-                "reference": "44cbda8a831844c8735734a8eab1b559762e98e0",
+                "url": "https://api.github.com/repos/neos/media-browser/zipball/82daa7a8f08a91276c655c9b90ea800d9bc1c2ca",
+                "reference": "82daa7a8f08a91276c655c9b90ea800d9bc1c2ca",
                 "shasum": ""
             },
             "require": {
@@ -7179,20 +7129,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-05-14T19:33:52+00:00"
+            "time": "2025-06-13T19:27:24+00:00"
         },
         {
             "name": "neos/neos",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/neos.git",
-                "reference": "2cdd6bb517b919bbdf36d5125f0c52a55dae8d92"
+                "reference": "e7d41f653ac27160595c508cf89332f029925da8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/neos/zipball/2cdd6bb517b919bbdf36d5125f0c52a55dae8d92",
-                "reference": "2cdd6bb517b919bbdf36d5125f0c52a55dae8d92",
+                "url": "https://api.github.com/repos/neos/neos/zipball/e7d41f653ac27160595c508cf89332f029925da8",
+                "reference": "e7d41f653ac27160595c508cf89332f029925da8",
                 "shasum": ""
             },
             "require": {
@@ -7205,7 +7155,7 @@
                 "neos/fluid-adaptor": "~9.0.0",
                 "neos/fusion": "self.version",
                 "neos/fusion-afx": "self.version",
-                "neos/fusion-form": "^2.0 || ^3.0",
+                "neos/fusion-form": "^2.1 || ^3.0",
                 "neos/media": "self.version",
                 "neos/media-browser": "self.version",
                 "neos/party": "~7.0.3",
@@ -7341,20 +7291,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-05-14T20:43:42+00:00"
+            "time": "2025-06-13T19:59:50+00:00"
         },
         {
             "name": "neos/neos-ui",
-            "version": "9.0.0",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/neos-ui.git",
-                "reference": "85303b217019c922560e4a7b7c6b858d6a20e5f2"
+                "reference": "a86d2b6f7f16ac5e6c138a2ff521d10396e61e75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/neos-ui/zipball/85303b217019c922560e4a7b7c6b858d6a20e5f2",
-                "reference": "85303b217019c922560e4a7b7c6b858d6a20e5f2",
+                "url": "https://api.github.com/repos/neos/neos-ui/zipball/a86d2b6f7f16ac5e6c138a2ff521d10396e61e75",
+                "reference": "a86d2b6f7f16ac5e6c138a2ff521d10396e61e75",
                 "shasum": ""
             },
             "require": {
@@ -7452,7 +7402,7 @@
             "description": "Neos CMS UI written in React",
             "support": {
                 "issues": "https://github.com/neos/neos-ui/issues",
-                "source": "https://github.com/neos/neos-ui/tree/9.0.0"
+                "source": "https://github.com/neos/neos-ui/tree/9.0.1"
             },
             "funding": [
                 {
@@ -7460,20 +7410,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T12:26:32+00:00"
+            "time": "2025-06-15T08:58:46+00:00"
         },
         {
             "name": "neos/neos-ui-compiled",
-            "version": "9.0.0",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/neos-ui-compiled.git",
-                "reference": "1da7aeaf5de084e8c1cbe530e11cb0d52acf0e05"
+                "reference": "f2d6183fcf5064ef22a7f97c00db5e586578e7c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/neos-ui-compiled/zipball/1da7aeaf5de084e8c1cbe530e11cb0d52acf0e05",
-                "reference": "1da7aeaf5de084e8c1cbe530e11cb0d52acf0e05",
+                "url": "https://api.github.com/repos/neos/neos-ui-compiled/zipball/f2d6183fcf5064ef22a7f97c00db5e586578e7c3",
+                "reference": "f2d6183fcf5064ef22a7f97c00db5e586578e7c3",
                 "shasum": ""
             },
             "require": {
@@ -7493,7 +7443,7 @@
             "notification-url": "https://packagist.org/downloads/",
             "support": {
                 "issues": "https://github.com/neos/neos-ui-compiled/issues",
-                "source": "https://github.com/neos/neos-ui-compiled/tree/9.0.0"
+                "source": "https://github.com/neos/neos-ui-compiled/tree/9.0.1"
             },
             "funding": [
                 {
@@ -7501,11 +7451,11 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T13:32:40+00:00"
+            "time": "2025-06-15T09:29:27+00:00"
         },
         {
             "name": "neos/nodetypes-basemixins",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-basemixins.git",
@@ -7631,7 +7581,7 @@
         },
         {
             "name": "neos/nodetypes-contentreferences",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/nodetypes-contentreferences.git",
@@ -7898,16 +7848,16 @@
         },
         {
             "name": "neos/redirecthandler",
-            "version": "6.0.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/redirecthandler.git",
-                "reference": "64568ce95ea6656121b5c0c31aa66e8eef2faba6"
+                "reference": "63c1a7c5ad2e81afc868f14af75405e670b1e430"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/redirecthandler/zipball/64568ce95ea6656121b5c0c31aa66e8eef2faba6",
-                "reference": "64568ce95ea6656121b5c0c31aa66e8eef2faba6",
+                "url": "https://api.github.com/repos/neos/redirecthandler/zipball/63c1a7c5ad2e81afc868f14af75405e670b1e430",
+                "reference": "63c1a7c5ad2e81afc868f14af75405e670b1e430",
                 "shasum": ""
             },
             "require": {
@@ -7963,7 +7913,7 @@
             "description": "Basic API to handle HTTP redirects with the Flow Framework",
             "support": {
                 "issues": "https://github.com/neos/redirecthandler/issues",
-                "source": "https://github.com/neos/redirecthandler/tree/6.0.1"
+                "source": "https://github.com/neos/redirecthandler/tree/6.0.2"
             },
             "funding": [
                 {
@@ -7971,20 +7921,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-07-26T18:28:27+00:00"
+            "time": "2025-06-02T21:04:47+00:00"
         },
         {
             "name": "neos/redirecthandler-databasestorage",
-            "version": "6.0.3",
+            "version": "6.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/redirecthandler-databasestorage.git",
-                "reference": "88e8907aa0c129a8270a1babc07e0152e114177a"
+                "reference": "d6a0e01d25a19c0152a326c35e69e964240dd210"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/redirecthandler-databasestorage/zipball/88e8907aa0c129a8270a1babc07e0152e114177a",
-                "reference": "88e8907aa0c129a8270a1babc07e0152e114177a",
+                "url": "https://api.github.com/repos/neos/redirecthandler-databasestorage/zipball/d6a0e01d25a19c0152a326c35e69e964240dd210",
+                "reference": "d6a0e01d25a19c0152a326c35e69e964240dd210",
                 "shasum": ""
             },
             "require": {
@@ -8048,7 +7998,7 @@
             "description": "A plugin for neos/redirecthandler to store redirects in the database",
             "support": {
                 "issues": "https://github.com/neos/redirecthandler-databasestorage/issues",
-                "source": "https://github.com/neos/redirecthandler-databasestorage/tree/6.0.3"
+                "source": "https://github.com/neos/redirecthandler-databasestorage/tree/6.0.4"
             },
             "funding": [
                 {
@@ -8056,7 +8006,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-10-24T10:01:18+00:00"
+            "time": "2025-06-02T20:54:25+00:00"
         },
         {
             "name": "neos/redirecthandler-neosadapter",
@@ -8195,16 +8145,16 @@
         },
         {
             "name": "neos/redirecthandler-ui",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/redirecthandler-ui.git",
-                "reference": "9decbe297d8517bda43ff4e27fcf4a64d7af9d20"
+                "reference": "3f474949cb3685bb3e80740bb6c19b61730cd0ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/redirecthandler-ui/zipball/9decbe297d8517bda43ff4e27fcf4a64d7af9d20",
-                "reference": "9decbe297d8517bda43ff4e27fcf4a64d7af9d20",
+                "url": "https://api.github.com/repos/neos/redirecthandler-ui/zipball/3f474949cb3685bb3e80740bb6c19b61730cd0ae",
+                "reference": "3f474949cb3685bb3e80740bb6c19b61730cd0ae",
                 "shasum": ""
             },
             "require": {
@@ -8316,7 +8266,7 @@
             "description": "This package provides a backend module to manage Neos.RedirectHandler redirects",
             "support": {
                 "issues": "https://github.com/neos/redirecthandler-ui/issues",
-                "source": "https://github.com/neos/redirecthandler-ui/tree/3.0.0"
+                "source": "https://github.com/neos/redirecthandler-ui/tree/3.0.1"
             },
             "funding": [
                 {
@@ -8324,20 +8274,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2023-10-13T11:24:29+00:00"
+            "time": "2025-06-02T21:14:29+00:00"
         },
         {
             "name": "neos/seo",
-            "version": "4.1.5",
+            "version": "4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/neos-seo.git",
-                "reference": "8fbc46202323ce2fbe6f681333d8893793d5acaa"
+                "reference": "514bf0f00662c914ce42bbf283c23cb8ed9bef64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/neos-seo/zipball/8fbc46202323ce2fbe6f681333d8893793d5acaa",
-                "reference": "8fbc46202323ce2fbe6f681333d8893793d5acaa",
+                "url": "https://api.github.com/repos/neos/neos-seo/zipball/514bf0f00662c914ce42bbf283c23cb8ed9bef64",
+                "reference": "514bf0f00662c914ce42bbf283c23cb8ed9bef64",
                 "shasum": ""
             },
             "require": {
@@ -8435,7 +8385,7 @@
             "description": "SEO configuration and tools for Neos",
             "support": {
                 "issues": "https://github.com/neos/neos-seo/issues",
-                "source": "https://github.com/neos/neos-seo/tree/4.1.5"
+                "source": "https://github.com/neos/neos-seo/tree/4.1.6"
             },
             "funding": [
                 {
@@ -8443,7 +8393,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T07:02:11+00:00"
+            "time": "2025-06-13T08:59:26+00:00"
         },
         {
             "name": "neos/utility-arrays",
@@ -8834,16 +8784,16 @@
         },
         {
             "name": "neos/workspace-ui",
-            "version": "9.0.3",
+            "version": "9.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/neos/workspace-ui.git",
-                "reference": "d3d0bb3adc74ce25c0274e412f63a2f5ec5838a8"
+                "reference": "eba4ac8905f2552b3e1e2e13ca2ce935c5637255"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/neos/workspace-ui/zipball/d3d0bb3adc74ce25c0274e412f63a2f5ec5838a8",
-                "reference": "d3d0bb3adc74ce25c0274e412f63a2f5ec5838a8",
+                "url": "https://api.github.com/repos/neos/workspace-ui/zipball/eba4ac8905f2552b3e1e2e13ca2ce935c5637255",
+                "reference": "eba4ac8905f2552b3e1e2e13ca2ce935c5637255",
                 "shasum": ""
             },
             "require": {
@@ -8909,7 +8859,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-04-03T12:04:24+00:00"
+            "time": "2025-06-10T17:52:38+00:00"
         },
         {
             "name": "phenx/php-font-lib",
@@ -9596,20 +9546,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.6",
+            "version": "4.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
+                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
-                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
+                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13",
                 "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
@@ -9618,26 +9568,23 @@
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "captainhook/captainhook": "^5.10",
+                "captainhook/captainhook": "^5.25",
                 "captainhook/plugin-composer": "^5.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "doctrine/annotations": "^1.8",
-                "ergebnis/composer-normalize": "^2.15",
-                "mockery/mockery": "^1.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "ergebnis/composer-normalize": "^2.47",
+                "mockery/mockery": "^1.6",
                 "paragonie/random-lib": "^2",
-                "php-mock/php-mock": "^2.2",
-                "php-mock/php-mock-mockery": "^1.3",
-                "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpbench/phpbench": "^1.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^8.5 || ^9",
-                "ramsey/composer-repl": "^1.4",
-                "slevomat/coding-standard": "^8.4",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.9"
+                "php-mock/php-mock": "^2.6",
+                "php-mock/php-mock-mockery": "^1.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpbench/phpbench": "^1.2.14",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "slevomat/coding-standard": "^8.18",
+                "squizlabs/php_codesniffer": "^3.13"
             },
             "suggest": {
                 "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
@@ -9672,19 +9619,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
+                "source": "https://github.com/ramsey/uuid/tree/4.8.1"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/ramsey",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-04-27T21:32:50+00:00"
+            "time": "2025-06-01T06:28:46+00:00"
         },
         {
             "name": "react/promise",
@@ -10332,16 +10269,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.21",
+            "version": "v6.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a3011c7b7adb58d89f6c0d822abb641d7a5f9719"
+                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a3011c7b7adb58d89f6c0d822abb641d7a5f9719",
-                "reference": "a3011c7b7adb58d89f6c0d822abb641d7a5f9719",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
+                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
                 "shasum": ""
             },
             "require": {
@@ -10406,7 +10343,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.21"
+                "source": "https://github.com/symfony/console/tree/v6.4.22"
             },
             "funding": [
                 {
@@ -10422,7 +10359,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-07T15:42:41+00:00"
+            "time": "2025-05-07T07:05:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -10560,7 +10497,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -10606,7 +10543,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -10626,16 +10563,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.2.2",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "87a71856f2f56e4100373e92529eed3171695cfb"
+                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/87a71856f2f56e4100373e92529eed3171695cfb",
-                "reference": "87a71856f2f56e4100373e92529eed3171695cfb",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ec2344cf77a48253bbca6939aa3d2477773ea63d",
+                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d",
                 "shasum": ""
             },
             "require": {
@@ -10670,7 +10607,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.2.2"
+                "source": "https://github.com/symfony/finder/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -10686,7 +10623,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-30T19:00:17+00:00"
+            "time": "2024-12-30T19:00:26+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -11087,16 +11024,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.2.5",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d"
+                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/87b7c93e57df9d8e39a093d32587702380ff045d",
-                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d",
+                "url": "https://api.github.com/repos/symfony/process/zipball/40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
                 "shasum": ""
             },
             "require": {
@@ -11128,7 +11065,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.2.5"
+                "source": "https://github.com/symfony/process/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -11144,7 +11081,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-13T12:21:46+00:00"
+            "time": "2025-04-17T09:11:12+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -11225,20 +11162,21 @@
         },
         {
             "name": "symfony/property-info",
-            "version": "v7.2.5",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "f00fd9685ecdbabe82ca25c7b739ce7bba99302c"
+                "reference": "200d230d8553610ada73ac557501dc4609aad31f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/f00fd9685ecdbabe82ca25c7b739ce7bba99302c",
-                "reference": "f00fd9685ecdbabe82ca25c7b739ce7bba99302c",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/200d230d8553610ada73ac557501dc4609aad31f",
+                "reference": "200d230d8553610ada73ac557501dc4609aad31f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/string": "^6.4|^7.0",
                 "symfony/type-info": "~7.1.9|^7.2.2"
             },
@@ -11290,7 +11228,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v7.2.5"
+                "source": "https://github.com/symfony/property-info/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -11306,20 +11244,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-06T16:27:19+00:00"
+            "time": "2025-04-04T13:12:05+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.4.21",
+            "version": "v6.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "c45f8f7763afb11e85772c0c1debb8f272c17f51"
+                "reference": "b836df93e9ea07d1d3ada58a679ef205d54b64d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/c45f8f7763afb11e85772c0c1debb8f272c17f51",
-                "reference": "c45f8f7763afb11e85772c0c1debb8f272c17f51",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/b836df93e9ea07d1d3ada58a679ef205d54b64d1",
+                "reference": "b836df93e9ea07d1d3ada58a679ef205d54b64d1",
                 "shasum": ""
             },
             "require": {
@@ -11388,7 +11326,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.4.21"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.22"
             },
             "funding": [
                 {
@@ -11404,7 +11342,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-27T13:27:38+00:00"
+            "time": "2025-05-12T08:02:50+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -11491,7 +11429,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.2.4",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -11533,7 +11471,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.2.4"
+                "source": "https://github.com/symfony/stopwatch/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -11553,16 +11491,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931"
+                "reference": "f3570b8c61ca887a9e2938e85cb6458515d2b125"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
-                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f3570b8c61ca887a9e2938e85cb6458515d2b125",
+                "reference": "f3570b8c61ca887a9e2938e85cb6458515d2b125",
                 "shasum": ""
             },
             "require": {
@@ -11620,7 +11558,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.2.6"
+                "source": "https://github.com/symfony/string/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -11636,28 +11574,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-20T20:18:16+00:00"
+            "time": "2025-04-20T20:19:01+00:00"
         },
         {
             "name": "symfony/type-info",
-            "version": "v7.2.5",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "c4824a6b658294c828e609d3d8dbb4e87f6a375d"
+                "reference": "bc9af22e25796d98078f69c0749ab3a9d3454786"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/c4824a6b658294c828e609d3d8dbb4e87f6a375d",
-                "reference": "c4824a6b658294c828e609d3d8dbb4e87f6a375d",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/bc9af22e25796d98078f69c0749ab3a9d3454786",
+                "reference": "bc9af22e25796d98078f69c0749ab3a9d3454786",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
-                "psr/container": "^1.1|^2.0"
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
             },
             "require-dev": {
-                "phpstan/phpdoc-parser": "^1.0|^2.0"
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
             },
             "type": "library",
             "autoload": {
@@ -11695,7 +11637,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v7.2.5"
+                "source": "https://github.com/symfony/type-info/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -11711,24 +11653,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T09:03:36+00:00"
+            "time": "2025-03-30T12:17:06+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.2.6",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "422b8de94c738830a1e071f59ad14d67417d7007"
+                "reference": "c9a1168891b5aaadfd6332ef44393330b3498c4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/422b8de94c738830a1e071f59ad14d67417d7007",
-                "reference": "422b8de94c738830a1e071f59ad14d67417d7007",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/c9a1168891b5aaadfd6332ef44393330b3498c4c",
+                "reference": "c9a1168891b5aaadfd6332ef44393330b3498c4c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "require-dev": {
                 "symfony/property-access": "^6.4|^7.0",
@@ -11771,7 +11714,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.2.6"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -11787,7 +11730,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-02T08:36:00+00:00"
+            "time": "2025-05-15T09:04:05+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -12102,12 +12045,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "af51c1a7b91dee6d4b920498946bf1de6a4efe86"
+                "reference": "0a95bcf39c5b55601cb073bc307d567a16e31dc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/af51c1a7b91dee6d4b920498946bf1de6a4efe86",
-                "reference": "af51c1a7b91dee6d4b920498946bf1de6a4efe86",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0a95bcf39c5b55601cb073bc307d567a16e31dc0",
+                "reference": "0a95bcf39c5b55601cb073bc307d567a16e31dc0",
                 "shasum": ""
             },
             "conflict": {
@@ -12167,11 +12110,12 @@
                 "bagisto/bagisto": "<2.1",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
-                "barryvdh/laravel-translation-manager": "<0.6.2",
+                "barryvdh/laravel-translation-manager": "<0.6.8",
                 "barzahlen/barzahlen-php": "<2.0.1",
                 "baserproject/basercms": "<=5.1.1",
                 "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
                 "bbpress/bbpress": "<2.6.5",
+                "bcit-ci/codeigniter": "<3.1.3",
                 "bcosca/fatfree": "<3.7.2",
                 "bedita/bedita": "<4",
                 "bednee/cooluri": "<1.0.30",
@@ -12207,6 +12151,7 @@
                 "centreon/centreon": "<22.10.15",
                 "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
                 "chriskacerguis/codeigniter-restserver": "<=2.7.1",
+                "chrome-php/chrome": "<1.14",
                 "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
                 "ckeditor/ckeditor": "<4.25",
                 "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
@@ -12268,9 +12213,12 @@
                 "dolibarr/dolibarr": "<19.0.2|==21.0.0.0-beta",
                 "dompdf/dompdf": "<2.0.4",
                 "doublethreedigital/guest-entries": "<3.1.2",
+                "drupal/admin_audit_trail": "<1.0.5",
                 "drupal/ai": "<1.0.5",
                 "drupal/alogin": "<2.0.6",
                 "drupal/cache_utility": "<1.2.1",
+                "drupal/commerce_alphabank_redirect": "<1.0.3",
+                "drupal/commerce_eurobank_redirect": "<2.1.1",
                 "drupal/config_split": "<1.10|>=2,<2.0.2",
                 "drupal/core": ">=6,<6.38|>=7,<7.102|>=8,<10.3.14|>=10.4,<10.4.5|>=11,<11.0.13|>=11.1,<11.1.5",
                 "drupal/core-recommended": ">=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
@@ -12279,11 +12227,13 @@
                 "drupal/gdpr": "<3.0.1|>=3.1,<3.1.2",
                 "drupal/google_tag": "<1.8|>=2,<2.0.8",
                 "drupal/ignition": "<1.0.4",
+                "drupal/lightgallery": "<1.6",
                 "drupal/link_field_display_mode_formatter": "<1.6",
                 "drupal/matomo": "<1.24",
                 "drupal/oauth2_client": "<4.1.3",
                 "drupal/oauth2_server": "<2.1",
                 "drupal/obfuscate": "<2.0.1",
+                "drupal/quick_node_block": "<2",
                 "drupal/rapidoc_elements_field_formatter": "<1.0.1",
                 "drupal/spamspan": "<3.2.1",
                 "drupal/tfa": "<1.10",
@@ -12296,6 +12246,7 @@
                 "elefant/cms": "<2.0.7",
                 "elgg/elgg": "<3.3.24|>=4,<4.0.5",
                 "elijaa/phpmemcacheadmin": "<=1.3",
+                "elmsln/haxcms": "<11",
                 "encore/laravel-admin": "<=1.8.19",
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enhavo/enhavo-app": "<=0.13.1",
@@ -12310,8 +12261,8 @@
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1-dev",
                 "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1-dev|>=5.4,<5.4.11.1-dev|>=2017.12,<2017.12.0.1-dev",
                 "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
-                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.26|>=3.3,<3.3.39",
-                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.38|>=3.3,<3.3.39",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1|>=5.3.0.0-beta1,<5.3.5",
                 "ezsystems/ezplatform-graphql": ">=1.0.0.0-RC1-dev,<1.0.13|>=2.0.0.0-beta1,<2.3.12",
                 "ezsystems/ezplatform-http-cache": "<2.3.16",
                 "ezsystems/ezplatform-kernel": "<1.2.5.1-dev|>=1.3,<1.3.35",
@@ -12393,6 +12344,7 @@
                 "guzzlehttp/oauth-subscriber": "<0.8.1",
                 "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
                 "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
+                "handcraftedinthealps/goodby-csv": "<1.4.3",
                 "harvesthq/chosen": "<1.8.7",
                 "helloxz/imgurl": "<=2.31",
                 "hhxsv5/laravel-s": "<3.7.36",
@@ -12402,9 +12354,10 @@
                 "hov/jobfair": "<1.0.13|>=2,<2.0.2",
                 "httpsoft/http-message": "<1.0.12",
                 "hyn/multi-tenant": ">=5.6,<5.7.2",
-                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.14",
+                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.21",
+                "ibexa/admin-ui-assets": ">=4.6.0.0-alpha1,<4.6.21",
                 "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4|>=4.2,<4.2.3|>=4.5,<4.5.6|>=4.6,<4.6.2",
-                "ibexa/fieldtype-richtext": ">=4.6,<4.6.19",
+                "ibexa/fieldtype-richtext": ">=4.6,<4.6.21",
                 "ibexa/graphql": ">=2.5,<2.5.31|>=3.3,<3.3.28|>=4.2,<4.2.3",
                 "ibexa/http-cache": ">=4.6,<4.6.14",
                 "ibexa/post-install": "<1.0.16|>=4.6,<4.6.14",
@@ -12518,7 +12471,7 @@
                 "marcwillmann/turn": "<0.3.3",
                 "matomo/matomo": "<1.11",
                 "matyhtf/framework": "<3.0.6",
-                "mautic/core": "<5.2.3",
+                "mautic/core": "<5.2.6|>=6.0.0.0-alpha,<6.0.2",
                 "mautic/core-lib": ">=1.0.0.0-beta,<4.4.13|>=5.0.0.0-alpha,<5.1.1",
                 "maximebf/debugbar": "<1.19",
                 "mdanter/ecc": "<2",
@@ -12640,6 +12593,7 @@
                 "phpmyadmin/phpmyadmin": "<5.2.2",
                 "phpmyfaq/phpmyfaq": "<3.2.5|==3.2.5|>=3.2.10,<=4.0.1",
                 "phpoffice/common": "<0.2.9",
+                "phpoffice/math": "<=0.2",
                 "phpoffice/phpexcel": "<=1.8.2",
                 "phpoffice/phpspreadsheet": "<1.29.9|>=2,<2.1.8|>=2.2,<2.3.7|>=3,<3.9",
                 "phpseclib/phpseclib": "<2.0.47|>=3,<3.0.36",
@@ -12706,6 +12660,7 @@
                 "rmccue/requests": ">=1.6,<1.8",
                 "robrichards/xmlseclibs": ">=1,<3.0.4",
                 "roots/soil": "<4.1",
+                "roundcube/roundcubemail": "<1.5.10|>=1.6,<1.6.11",
                 "rudloff/alltube": "<3.0.3",
                 "rudloff/rtmpdump-bin": "<=2.3.1",
                 "s-cart/core": "<6.9",
@@ -12773,7 +12728,7 @@
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "ssddanbrown/bookstack": "<24.05.1",
-                "starcitizentools/citizen-skin": ">=2.6.3,<2.31",
+                "starcitizentools/citizen-skin": ">=2.4.2,<3.3.1",
                 "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2",
                 "statamic/cms": "<=5.16",
                 "stormpath/sdk": "<9.9.99",
@@ -12957,7 +12912,7 @@
                 "yiisoft/yii2-elasticsearch": "<2.0.5",
                 "yiisoft/yii2-gii": "<=2.2.4",
                 "yiisoft/yii2-jui": "<2.0.4",
-                "yiisoft/yii2-redis": "<2.0.8",
+                "yiisoft/yii2-redis": "<2.0.20",
                 "yikesinc/yikes-inc-easy-mailchimp-extender": "<6.8.6",
                 "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
                 "yourls/yourls": "<=1.8.2",
@@ -13036,7 +12991,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-27T20:05:51+00:00"
+            "time": "2025-06-13T22:05:09+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
  - Upgrading neos/content-repository-search from version 5.0.1 to 5.0.3
  - Upgrading neos/contentgraph-doctrinedbaladapter from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-core from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-export from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-nodeaccess from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-nodemigration from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepository-structureadjustment from version 9.0.3 to 9.0.4
  - Upgrading neos/contentrepositoryregistry from version 9.0.3 to 9.0.4
  - Upgrading neos/diff from version 9.0.3 to 9.0.4
  - Upgrading neos/fusion from version 9.0.3 to 9.0.4
  - Upgrading neos/fusion-afx from version 9.0.3 to 9.0.4
  - Upgrading neos/media from version 9.0.3 to 9.0.4
  - Upgrading neos/media-browser from version 9.0.3 to 9.0.4
  - Upgrading neos/neos from version 9.0.3 to 9.0.4
  - Upgrading neos/neos-ui from version 9.0.0 to 9.0.1
  - Upgrading neos/neos-ui-compiled from version 9.0.0 to 9.0.1
  - Upgrading neos/nodetypes-basemixins from version 9.0.3 to 9.0.4
  - Upgrading neos/nodetypes-contentreferences from version 9.0.3 to 9.0.4
  - Upgrading neos/redirecthandler from version 6.0.1 to 6.0.2
  - Upgrading neos/redirecthandler-databasestorage from version 6.0.3 to 6.0.4
  - Upgrading neos/redirecthandler-ui from version 3.0.0 to 3.0.1
  - Upgrading neos/seo from version 4.1.5 to 4.1.6
  - Upgrading neos/workspace-ui from version 9.0.3 to 9.0.4
  - Upgrading brick/math from version 0.12.3 to 0.13.1
  - Upgrading carbon/eel from version 2.21.1 to 2.22.0
  - Upgrading doctrine/orm from version 2.20.3 to 2.20.4
  - Upgrading flowpack/elasticsearch-contentrepositoryadaptor from version 9.0.0 to 9.0.2
  - Upgrading google/cloud-core from version v1.62.3 to v1.63.0
  - Upgrading google/protobuf from version v4.31.0 to v4.31.1
  - Upgrading justinrainbow/json-schema from version 6.4.1 to 6.4.2
  - Upgrading matthiasmullie/minify from version 1.3.73 to 1.3.74
  - Upgrading ramsey/uuid from version 4.7.6 to 4.8.1
  - Upgrading symfony/console from version v6.4.21 to v6.4.22
  - Upgrading symfony/filesystem from version v7.2.0 to v7.3.0
  - Upgrading symfony/finder from version v7.2.2 to v7.3.0
  - Upgrading symfony/process from version v7.2.5 to v7.3.0
  - Upgrading symfony/property-info from version v7.2.5 to v7.3.0
  - Upgrading symfony/serializer from version v6.4.21 to v6.4.22
  - Upgrading symfony/stopwatch from version v7.2.4 to v7.3.0
  - Upgrading symfony/string from version v7.2.6 to v7.3.0
  - Upgrading symfony/type-info from version v7.2.5 to v7.3.0
  - Upgrading symfony/var-exporter from version v7.2.6 to v7.3.0